### PR TITLE
Attempt to recover previous webhook

### DIFF
--- a/bin/register-webhook.js
+++ b/bin/register-webhook.js
@@ -35,7 +35,11 @@ var WebhookRegistrar = function () {
             if (err) {
               reject(err);
             } else if (typeof body === 'string') {
-              reject(body);
+              if (body === 'A webhook with that callback, model, and token already exists') {
+                resolve('Unknown Webhook ID - recovering previous session');
+              } else {
+                reject(body);
+              }
             } else {
               _this.webhookID = body.id;
               resolve(body.id);

--- a/src/register-webhook.js
+++ b/src/register-webhook.js
@@ -25,7 +25,11 @@ class WebhookRegistrar {
           if (err) {
             reject(err);
           } else if (typeof body === 'string') {
-            reject(body);
+            if (body === 'A webhook with that callback, model, and token already exists') {
+              resolve('Unknown Webhook ID - recovering previous session');
+            } else {
+              reject(body);
+            }
           } else {
             this.webhookID = body.id;
             resolve(body.id);

--- a/test/test-register-webhook.js
+++ b/test/test-register-webhook.js
@@ -55,18 +55,37 @@ tap.test('webhook registrar', t1 => {
       });
 
       t3.test('with a returned error string', t4 => {
-        const errString = 'Error string';
-        post.yields(null, null, errString);
-        reg.register(callbackURL, modelID)
-          .then(() => {
-            t4.fail('rejects');
-          })
-          .catch(e => {
-            t4.pass('rejects');
-            t4.equals(post.callCount, 1, 'posts to Trello');
-            t4.equals(e, errString, 'passes error');
-          })
-          .then(t4.done);
+        t4.test('unknown error string', t5 => {
+          const errString = 'Error string';
+          post.yields(null, null, errString);
+          reg.register(callbackURL, modelID)
+            .then(() => {
+              t5.fail('rejects');
+            })
+            .catch(e => {
+              t5.pass('rejects');
+              t5.equals(post.callCount, 1, 'posts to Trello');
+              t5.equals(e, errString, 'passes error');
+            })
+            .then(t5.done);
+        });
+
+        t4.test('with error indicating webhook already exists', t5 => {
+          const errString = 'A webhook with that callback, model, and token already exists';
+          post.yields(null, null, errString);
+          reg.register(callbackURL, modelID)
+            .then(id => {
+              t5.pass('resolves');
+              t5.equals(post.callCount, 1, 'posts to Trello');
+              t5.ok(id.startsWith('Unknown Webhook ID'), 'sends a notice that the webhook ID is unknown');
+            })
+            .catch(() => {
+              t5.fail('rejects');
+            })
+            .then(t5.done);
+        });
+
+        t4.done();
       });
 
       t3.test('with a returned webhook object', t4 => {


### PR DESCRIPTION
If you try to register a webhook where `{ callbackURL, model, token }` has already been registered, Trello returns a 400 error with the body set to a string:

> A webhook with that callback, model, and token already exists

This is recoverable.  While there's no way to get the webhook ID (@trello: this would be a really great API addition), since we own the callback URL, there's no reason we can't just start the server and continue to service webhook requests.

Resolves, but sends back `Unknown Webhook ID` along with a little description of what's happening.  Also won't try to clean up since the webhook ID isn't set anywhere.
